### PR TITLE
PADV 317 - Creating a Composite Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,50 @@
-# composite-build-action
+# About
+
+Composite Action to build and push Docker images from Tutor to Docker Hub.
+
+-   [Usage](https://github.com/Pearson-Advance/tutor-build-image-action#usage)
+-   [Customizing](https://github.com/Pearson-Advance/tutor-build-image-action#customizing)
+    -   [inputs](https://github.com/Pearson-Advance/tutor-build-image-action#inputs)
+
+# Usage
+
+In this example you will see how to use this Composite Action. Also the different parameters that are
+needed to start the workflow.
+
+```
+name: Tutor Build Action Test
+
+on:
+  push:
+    branches:
+      - 'vue/PADV-317'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Build Image
+        uses: pearson-advance/tutor-build-image-action@0.0.1.alpha
+        with:
+          image-to-be-built: 'openedx'
+          repository-name: 'pearsonopenedxops'
+          image-name: 'tutor-test'
+          docker-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker-token: ${{ secrets.DOCKERHUB_TOKEN }}
+```
+
+# Customizing
+
+## inputs
+
+|      **Name**     | **Type** |                                               **Description**                                              |
+|:-----------------:|:--------:|:----------------------------------------------------------------------------------------------------------:|
+| python-version    | String   | The version of Python. It is useful since venv will be created from it. Defaults to 3.8.                                    |
+| tutor-version     | String   | The version of Tutor to be installed. Defaults to 15.3.0.                                                  |
+| repository-name   | String   | The name of the repository created in Docker Hub in which the newly built image will be pushed and tagged. |
+| image-to-be-built | String   | The image to be built.                                                                 |
+| image-name        | String   | The name of the image that will be pushed to Docker Hub.                                                   |
+| image-tag         | String   | The tag of the image that will be pushed to Docker Hub. Defaults to latest.                                |
+| docker-username          | String   | Username of the user created in Docker Hub.                                                                |
+| docker-token          | String   | Password of the user created in Docker Hub.                                                                |

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,70 @@
+name: 'Composite Action'
+description: 'This workflow is able to build and push a specified Image from Tutor to Docker Hub.'
+
+inputs:
+  python-version:
+    description: 'Version of Python. It is useful since venv will be created from it.'
+    required: false
+    default: '3.8'
+  tutor-version:
+    description: 'Tutor version to be installed. It takes 15.3.0 by default.'
+    required: true
+    default: '15.3.0'
+  repository-name:
+    description: 'Name of the repository in Docker Hub.'
+    required: true
+  image-to-be-built:
+    description: 'Image to be built.'
+    required: true
+  image-name:
+    description: 'This input refers the name of the image that will be pushed to Docker Hub.'
+    required: true
+  image-tag:
+    description: 'Tag of the image that will be pushed to Docker Hub. It assigns latest by default.'
+    required: false
+    default: 'latest'
+  docker-username:
+    description: 'Docker Hub username.'
+    required: true
+  docker-token:
+    description: 'Docker Hub token.'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Create and activate the env
+      run: |
+        python -m venv venv
+        source venv/bin/activate
+      shell: bash
+
+    - name: Install Tutor
+      run: pip install tutor==${{ inputs.tutor-version }}
+      shell: bash
+
+    - name: Render Tutor Templates
+      run: tutor config save
+      shell: bash
+
+    - name: Build image
+      run: |
+        tutor images build ${{ inputs.image-to-be-built }} \
+            --docker-arg --tag="${{ inputs.repository-name }}/${{ inputs.image-name }}:${{ inputs.image-tag }}"
+      shell: bash
+
+    - name: Login to Docker Hub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ inputs.docker-username }}
+        password: ${{ inputs.docker-token }}
+
+    - name: Push image to DockerHub
+      run: docker push ${{ inputs.repository-name }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
+      shell: bash


### PR DESCRIPTION
## Ticket

https://agile-jira.pearson.com/browse/PADV-317

## Description

This PR aims to create a composite action to build and push tutor image to Docker Hub.

## Type of Change

- Adding action that contains steps to build and push tutor image.

## Proof of Concept

This is a PoC, so the important to see or evaluate in this PR is each step in the workflow.

## How to test

- There is a branch called `vue/PADV-317` in openedx-platform that just contains one workflow. That workflow uses this Composite Action.
- There is a repository (only for test) created in Docker Hub called `pearsonopenedxops/tutor-test`.
- The workflow is activated when it push a commit to the `vue/PADV-317` branch.
- It is recommend to activate the workflow making a minor change on the code, for example change the tag of the image.

## Screenshot

The screenshot below shows the result of the last execution of the workflow.

![image](https://user-images.githubusercontent.com/73655023/219482766-f9278b4a-b943-4736-bd48-50583b6873ac.png)

## Report

This is the first task for creating an image building pipeline. The purpose of this task is to assess the capabilities, constraints and scope of this process in GitHub Actions.

_Source: https://docs.github.com/en/actions/creating-actions/creating-a-composite-action_

**Capabilities** 

Composite Actions allow us to bundle multiple workflow steps into a single action, combining multiple run commands into a single reusable action. They also allow you to create nesting actions on top of other actions. Also Composite Actions are intended to be more isolated and generic.

**Constraints**

- Composite Actions can be nested up to 10 layers.
- Composite Actions cannot use secrets, not from the workflow nor as parameters. And this could be a fairly big limit.
- You can only have a flat list of steps and no control over their execution. it means that it is not possible to add a conditional.
- Each Composite Actions definition requires its own repository, which must be public, and a metadata file. And if you want to execute a script from a file, then you will also need the script file in the same repository.
- You cannot have multiple jobs in a single Composite Action.
- Using Composite Actions, instead, all you have is a single log of a single step, even if it contains multiple steps.

_Source: https://dev.to/n3wt0n/composite-actions-vs-reusable-workflows-what-is-the-difference-github-actions-11kd_

**Scope**

This scope only covers tutor as an example to build and push the image that it is generated. The image is built according to the parameters that are received.

**Results**

In this case of a tutor image, it took around 30 minutes to complete the whole process. It is important to mention that it does not contain a cache. The repository that uses this composite action is https://github.com/Pearson-Advance/edx-platform/tree/vue/PADV-317.

**Conclusion**

Composite Actions allow you to pack multiple tasks and operations in a single step, to be reused inside a job. It is very useful because you do not have to add the whole workflow inside another one. Finally, you can replicate the same process in JavaScript, which allows you not to be tied to GitHub Action.

## Reviewers

- [x] @anfbermudezme
- [x] @Jacatove
- [x] @Squirrel18